### PR TITLE
🚀 Preview IG site on pull request updates

### DIFF
--- a/.github/workflows/deploy_preview.yml
+++ b/.github/workflows/deploy_preview.yml
@@ -1,0 +1,58 @@
+name: 🚀 Deploy Implementation Guide Site Preview on Netlify
+
+on:
+  pull_request:
+    types: [opened, reopened, edited, synchronize] 
+
+jobs:
+  publish:
+    name: 📝 Publish Implementation Guide
+    runs-on: ubuntu-18.04
+    steps:
+      - name: 👩‍💻 Checkout code
+        uses: actions/checkout@v3
+         
+      - name: 🛠 Set up OpenJDK
+        uses: actions/setup-java@v1
+        with:
+          java-version: 8
+
+      - name: 🛠 Set up Jekyll
+        run: |
+          sudo apt-get update
+          sudo apt-get -y install ruby-full build-essential zlib1g-dev
+          sudo gem install jekyll bundler
+
+      - name: 🛠 Set up Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: 12 
+
+      - name: 🛠 Install SUSHI and add FSH definitions
+        run: |
+          npm install -g fsh-sushi
+          sushi .
+
+      - name: ⬆️ Update IG publisher
+        run: |
+          sudo apt-get -y install iputils-ping
+          chmod +x ./_updatePublisher.sh
+          ./_updatePublisher.sh -y
+
+      - name: 🚦 Validate IG
+        run: |
+          chmod +x ./_genonce.sh
+          ./_genonce.sh
+
+      - name: 🚀 Deploy IG to Netlify
+        uses: nwtgck/actions-netlify@v1.2
+        with:
+          publish-dir: './output'
+          deploy-message: "🚀 Deploy from GitHub Actions"
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          alias: deploy-preview-${{ github.event.number }}
+          fails-without-credentials: true
+        env:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+      

--- a/.github/workflows/deploy_preview.yml
+++ b/.github/workflows/deploy_preview.yml
@@ -1,4 +1,4 @@
-name: 🚀 Deploy Implementation Guide Site Preview on Netlify
+name: 🚀 Deploy IG Site Preview
 
 on:
   pull_request:
@@ -6,7 +6,7 @@ on:
 
 jobs:
   publish:
-    name: 📝 Publish Implementation Guide
+    name: 📝 Preview Implementation Guide
     runs-on: ubuntu-18.04
     steps:
       - name: 👩‍💻 Checkout code
@@ -44,15 +44,31 @@ jobs:
           chmod +x ./_genonce.sh
           ./_genonce.sh
 
-      - name: 🚀 Deploy IG to Netlify
+      - name: 🚀 Deploy to Netlify
         uses: nwtgck/actions-netlify@v1.2
+        id: netlify
         with:
           publish-dir: './output'
           deploy-message: "🚀 Deploy from GitHub Actions"
           github-token: ${{ secrets.GITHUB_TOKEN }}
           alias: deploy-preview-${{ github.event.number }}
           fails-without-credentials: true
+          enable-pull-request-comment: false
+          enable-commit-comment: false
+          enable-commit-status: false
         env:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
-      
+
+      - name: 🏷 PR Deploy Preview Comment
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          message: |
+            ### :rocket: IG Site Preview Deployed
+
+            Latest commit: ${{ github.event.pull_request.head.sha }}
+
+            [View deployment](${{ steps.netlify.outputs.deploy-url }})
+
+
+


### PR DESCRIPTION
## Motivation
Developers can currently build the IG locally and preview it in their browser. However, it would be nice to view the published site at a publicly accessible URL so that anyone reviewing the PR may review the IG and make comments on the PR.  

## Approach
Each time the PR is updated (new commit pushed), deploy the IG to a URL unique to the pull request. This PR adds a couple of steps to the github workflow which 1) deploy the site to netlify and 2) add a comment on the PR with the deploy preview url.